### PR TITLE
Return company profile data even when charge details are missing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/uri/web/service/ApiServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/uri/web/service/ApiServiceImpl.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriTemplate;
 
+import com.google.api.client.http.HttpStatusCodes;
+
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
@@ -64,6 +66,11 @@ public class ApiServiceImpl implements ApiService {
             return response.getData();
             
         } catch (ApiErrorResponseException e) {
+            if (e.getStatusCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
+                // Don't throw a ServiceException if just 404 as we should
+                // still return the company profile data without the mortgages.
+                return null;
+            }
             logger.debug(FAILED_CHARGES_PREFIX + uri + FAILED_SUFFIX + e);
             throw new ServiceException("Error retrieving charges", e);
         } catch (URIValidationException e) {

--- a/src/main/java/uk/gov/companieshouse/uri/web/service/CompanyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/uri/web/service/CompanyServiceImpl.java
@@ -45,12 +45,14 @@ public class CompanyServiceImpl implements CompanyService {
         
         if (companyDetails.hasCharges()) {
             ChargesApi chargesApi = apiService.getCharges(companyNumber);
-            try {
-                companyDetails.setMortgageTotals(companyDetailsTransformer.chargesApiToMortgageTotals(chargesApi));
-            }
-            catch (RuntimeException e) {
-                logger.error("Exception during transform of chargesApi", e);
-                throw new ServiceException("Error transforming charges", e);
+            if (chargesApi != null) {
+                try {
+                    companyDetails.setMortgageTotals(companyDetailsTransformer.chargesApiToMortgageTotals(chargesApi));
+                }
+                catch (RuntimeException e) {
+                    logger.error("Exception during transform of chargesApi", e);
+                    throw new ServiceException("Error transforming charges", e);
+                }
             }
         }
         return companyDetails;

--- a/src/test/java/uk/gov/companieshouse/uri/web/service/ApiServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/service/ApiServiceImplTest.java
@@ -156,7 +156,7 @@ class ApiServiceImplTest {
     @Test
     void getChargesApiErrorResponseException404() throws ApiErrorResponseException, URIValidationException {
         mockChargesApiCall();
-        Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "", new HttpHeaders());
+        final Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "", new HttpHeaders());
         ApiErrorResponseException apiErrorResponseException = new ApiErrorResponseException(builder);
         when(chargesGet.execute()).thenThrow(apiErrorResponseException);
         

--- a/src/test/java/uk/gov/companieshouse/uri/web/service/ApiServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/service/ApiServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.times;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +14,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpResponseException.Builder;
 
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -142,6 +148,20 @@ class ApiServiceImplTest {
         });
 
         assertEquals("Error retrieving charges", exception.getMessage());
+        verify(mockApiClient, times(1)).charges();
+        verify(chargesResourceHandler,times(1)).get(URI_PREFIX + COMPANY_NUMBER + GET_CHARGES_URI_SUFFIX);
+        verify(chargesGet, times(1)).execute();
+    }
+    
+    @Test
+    void getChargesApiErrorResponseException404() throws ApiErrorResponseException, URIValidationException {
+        mockChargesApiCall();
+        Builder builder = new HttpResponseException.Builder(HttpStatusCodes.STATUS_CODE_NOT_FOUND, "", new HttpHeaders());
+        ApiErrorResponseException apiErrorResponseException = new ApiErrorResponseException(builder);
+        when(chargesGet.execute()).thenThrow(apiErrorResponseException);
+        
+        assertNull(testApiService.getCharges(COMPANY_NUMBER));
+
         verify(mockApiClient, times(1)).charges();
         verify(chargesResourceHandler,times(1)).get(URI_PREFIX + COMPANY_NUMBER + GET_CHARGES_URI_SUFFIX);
         verify(chargesGet, times(1)).execute();


### PR DESCRIPTION
If a company profile response from the CHS API indicates hasCharges="true", we should still return the profile, even when the subsequent call to the charges API returns 404.  The 404 is due to a data issue where the mortgage charge details are not present.

Resolves:
CM-93