### PR TITLE
Adjust headers and remove session cookie

### DIFF
--- a/src/main/java/uk/gov/companieshouse/uri/web/controller/ViewController.java
+++ b/src/main/java/uk/gov/companieshouse/uri/web/controller/ViewController.java
@@ -139,6 +139,7 @@ public class ViewController {
                 .contentType(mediaType)
                 .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                 .cacheControl(CacheControl.noStore().mustRevalidate())
+                .header(HttpHeaders.PRAGMA, "no-cache")
                 .body(body);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,5 @@ developer.url=${DEVELOPER_URL}
 chs.url=${CHS_URL}
 govuk.ch.url=${GOVUK_CH_URL}
 api.url=${API_URL}
-#Turn off session cookie
+#Turn off JSESSIONID cookie
 server.servlet.session.tracking-modes=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,5 @@ developer.url=${DEVELOPER_URL}
 chs.url=${CHS_URL}
 govuk.ch.url=${GOVUK_CH_URL}
 api.url=${API_URL}
+#Turn off session cookie
+server.servlet.session.tracking-modes=

--- a/src/test/java/uk/gov/companieshouse/uri/web/controller/ViewControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/controller/ViewControllerIntegrationTest.java
@@ -243,7 +243,8 @@ public class ViewControllerIntegrationTest {
         result.andExpect(status().isOk())
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
                         MediaType.TEXT_HTML_VALUE + UTF8_CHARSET_SUFFIX))
-                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store, must-revalidate"));
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store, must-revalidate"))
+                .andExpect(header().string(HttpHeaders.PRAGMA, "no-cache"));
     }
     
     @Test

--- a/src/test/java/uk/gov/companieshouse/uri/web/controller/ViewControllerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/controller/ViewControllerIntegrationTest.java
@@ -1,0 +1,258 @@
+package uk.gov.companieshouse.uri.web.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import uk.gov.companieshouse.uri.web.UriWebApplication;
+import uk.gov.companieshouse.uri.web.model.Accounts;
+import uk.gov.companieshouse.uri.web.model.Address;
+import uk.gov.companieshouse.uri.web.model.CompanyDetails;
+import uk.gov.companieshouse.uri.web.model.Returns;
+import uk.gov.companieshouse.uri.web.model.SicCodes;
+import uk.gov.companieshouse.uri.web.service.CompanyService;
+
+@AutoConfigureMockMvc
+@SpringBootTest(classes = UriWebApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+public class ViewControllerIntegrationTest {
+    
+    private static final String UTF8_CHARSET_SUFFIX = ";charset=UTF-8";
+    private static final String COMPANY_NUMBER = "05448736";
+    
+    @Autowired
+    private MockMvc mockMvc;
+    
+    @MockBean
+    private CompanyService companyService;
+    
+    private CompanyDetails companyDetails;
+    
+    @BeforeEach
+    protected void setUp() {
+        companyDetails = new CompanyDetails();
+        companyDetails.setRegisteredOfficeAddress(new Address());
+        companyDetails.setAccounts(new Accounts());
+        companyDetails.setReturns(new Returns());
+        companyDetails.setSicCodes(new SicCodes());
+        
+        when(companyService.getCompanyDetails(COMPANY_NUMBER)).thenReturn(companyDetails);
+    }
+    
+    @Test
+    void noAcceptHeaderAndNoExtensionReturnsHTML() throws Exception { 
+       mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER))
+       .andExpect(status().isOk())
+       .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+               MediaType.TEXT_HTML_VALUE + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void noAcceptHeaderAndHTMLExtensionReturnsHTML() throws Exception {
+       mockMvc.perform(get("/doc/company/{company}.html", COMPANY_NUMBER))
+       .andExpect(status().isOk())
+       .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+               MediaType.TEXT_HTML_VALUE + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void textHtmlAcceptHeaderAndNoExtensionReturnsHTML() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(MediaType.TEXT_HTML_VALUE));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        MediaType.TEXT_HTML_VALUE + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void noAcceptHeaderAndJSONExtensionReturnsJSON() throws Exception {
+       mockMvc.perform(get("/doc/company/{company}.json", COMPANY_NUMBER))
+       .andExpect(status().isOk())
+       .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+               MediaType.APPLICATION_JSON_VALUE + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void applicationJsonAcceptHeaderAndNoExtensionReturnsJSON() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(MediaType.APPLICATION_JSON_VALUE));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        MediaType.APPLICATION_JSON_VALUE + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void noAcceptHeaderAndRDFExtensionReturnsRDF() throws Exception {
+       mockMvc.perform(get("/doc/company/{company}.rdf", COMPANY_NUMBER))
+       .andExpect(status().isOk())
+       .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+               ViewController.APPLICATION_RDFXML + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void applicationRdfAcceptHeaderAndNoExtensionReturnsRDF() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.APPLICATION_RDFXML));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.APPLICATION_RDFXML + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void noAcceptHeaderAndXMLExtensionReturnsXML() throws Exception {
+       mockMvc.perform(get("/doc/company/{company}.xml", COMPANY_NUMBER))
+       .andExpect(status().isOk())
+       .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+               MediaType.TEXT_XML_VALUE + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void applicationXmlAcceptHeaderAndNoExtensionReturnsXML() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(MediaType.APPLICATION_XML_VALUE));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        MediaType.TEXT_XML_VALUE + UTF8_CHARSET_SUFFIX));
+    }
+
+    @Test
+    void applicationXxmlAcceptHeaderAndNoExtensionReturnsXML() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.APPLICATION_XXML));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        MediaType.TEXT_XML_VALUE + UTF8_CHARSET_SUFFIX));
+    }
+
+    @Test
+    void noAcceptHeaderAndCSVExtensionReturnsCSV() throws Exception {
+       mockMvc.perform(get("/doc/company/{company}.csv", COMPANY_NUMBER))
+       .andExpect(status().isOk())
+       .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+               ViewController.TEXT_CSV + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void textCsvAcceptHeaderAndNoExtensionReturnsCSV() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.TEXT_CSV));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.TEXT_CSV + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void textCommaSeparatedValuesAcceptHeaderAndNoExtensionReturnsCSV() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.TEXT_COMMA_SEPARATED_VALUES));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.TEXT_CSV + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void applicationCsvAcceptHeaderAndNoExtensionReturnsCSV() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.APPLICATION_CSV));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.TEXT_CSV + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void applicationExcelAcceptHeaderAndNoExtensionReturnsCSV() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.APPLICATION_EXCEL));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.TEXT_CSV + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void noAcceptHeaderAndYAMLExtensionReturnsYAML() throws Exception {
+       mockMvc.perform(get("/doc/company/{company}.yaml", COMPANY_NUMBER))
+       .andExpect(status().isOk())
+       .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+               ViewController.APPLICATION_YAML + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void applicationYamlAcceptHeaderAndNoExtensionReturnsYAML() throws Exception { 
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.APPLICATION_YAML));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.APPLICATION_YAML + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void applicationXyamlAcceptHeaderAndNoExtensionReturnsYAML() throws Exception {  
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.APPLICATION_XYAML));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.APPLICATION_YAML + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void textYamlAcceptHeaderAndNoExtensionReturnsYAML() throws Exception {  
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.TEXT_YAML));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.APPLICATION_YAML + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void textXyamlExcelAcceptHeaderAndNoExtensionReturnsYAML() throws Exception {   
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER)
+               .accept(ViewController.TEXT_XYAML));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        ViewController.APPLICATION_YAML + UTF8_CHARSET_SUFFIX));
+    }
+    
+    @Test
+    void confirmCacheControlHeaderInResponse() throws Exception {    
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        MediaType.TEXT_HTML_VALUE + UTF8_CHARSET_SUFFIX))
+                .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store, must-revalidate"));
+    }
+    
+    @Test
+    void confirmCORSHeaderInResponse() throws Exception {
+        ResultActions result = mockMvc.perform(get("/doc/company/{company}", COMPANY_NUMBER));
+  
+        result.andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, 
+                        MediaType.TEXT_HTML_VALUE + UTF8_CHARSET_SUFFIX))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "*"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/uri/web/controller/ViewControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/controller/ViewControllerTest.java
@@ -65,82 +65,64 @@ class ViewControllerTest {
     void html() {
         mockTemplateProcess(ViewController.HTML_VIEW);
         
-        ResponseEntity<String> responseEntity = testViewController.html(COMPANY_NUMBER, request, response);
-        
-        CompanyDetails companyDetails = (CompanyDetails) contextCaptor.getValue()
-                .getVariable(ViewController.CONTEXT_VAR_NAME);
-        assertEquals(COMPANY_NUMBER, companyDetails.getCompanyNumber());
-        assertEquals(MediaType.TEXT_HTML, responseEntity.getHeaders().getContentType());
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertModelAndResponse(testViewController.html(COMPANY_NUMBER, request, response), 
+                MediaType.TEXT_HTML_VALUE);
     }
     
     @Test
     void json() {
         mockTemplateProcess(ViewController.JSON_VIEW);
         
-        ResponseEntity<String> responseEntity = testViewController.json(COMPANY_NUMBER, request, response);
-        
-        CompanyDetails companyDetails = (CompanyDetails) contextCaptor.getValue()
-                .getVariable(ViewController.CONTEXT_VAR_NAME);
-        assertEquals(COMPANY_NUMBER, companyDetails.getCompanyNumber());
-        assertEquals(MediaType.APPLICATION_JSON, responseEntity.getHeaders().getContentType());
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertModelAndResponse(testViewController.json(COMPANY_NUMBER, request, response), 
+                MediaType.APPLICATION_JSON_VALUE);
     }
     
     @Test
     void rdf() {
         mockTemplateProcess(ViewController.RDF_VIEW);
         
-        ResponseEntity<String> responseEntity = testViewController.rdf(COMPANY_NUMBER, request, response);
-        
-        CompanyDetails companyDetails = (CompanyDetails) contextCaptor.getValue()
-                .getVariable(ViewController.CONTEXT_VAR_NAME);
-        assertEquals(COMPANY_NUMBER, companyDetails.getCompanyNumber());
-        assertEquals(ViewController.RDF_CONTENT_TYPE, responseEntity.getHeaders().getContentType().toString());
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertModelAndResponse(testViewController.rdf(COMPANY_NUMBER, request, response), 
+                ViewController.APPLICATION_RDFXML);
     }
     
     @Test
     void xml() {
         mockTemplateProcess(ViewController.XML_VIEW);
         
-        ResponseEntity<String> responseEntity = testViewController.xml(COMPANY_NUMBER, request, response);
-        
-        CompanyDetails companyDetails = (CompanyDetails) contextCaptor.getValue()
-                .getVariable(ViewController.CONTEXT_VAR_NAME);
-        assertEquals(COMPANY_NUMBER, companyDetails.getCompanyNumber());
-        assertEquals(MediaType.APPLICATION_XML, responseEntity.getHeaders().getContentType());
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertModelAndResponse(testViewController.xml(COMPANY_NUMBER, request, response), 
+                MediaType.TEXT_XML_VALUE);
     }
     
     @Test
     void csv() {
         mockTemplateProcess(ViewController.CSV_VIEW);
-        
-        ResponseEntity<String> responseEntity = testViewController.csv(COMPANY_NUMBER, request, response);
-        
-        CompanyDetails companyDetails = (CompanyDetails) contextCaptor.getValue()
-                .getVariable(ViewController.CONTEXT_VAR_NAME);
-        assertEquals(COMPANY_NUMBER, companyDetails.getCompanyNumber());
-        assertEquals(ViewController.CSV_CONTENT_TYPE, responseEntity.getHeaders().getContentType().toString());
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+
+        assertModelAndResponse(testViewController.csv(COMPANY_NUMBER, request, response), 
+                ViewController.TEXT_CSV);
     }
     
     @Test
     void yaml() {
         mockTemplateProcess(ViewController.YAML_VIEW);
-        
-        ResponseEntity<String> responseEntity = testViewController.yaml(COMPANY_NUMBER, request, response);
-        
-        CompanyDetails companyDetails = (CompanyDetails) contextCaptor.getValue()
-                .getVariable(ViewController.CONTEXT_VAR_NAME);
-        assertEquals(COMPANY_NUMBER, companyDetails.getCompanyNumber());
-        assertEquals(ViewController.YAML_CONTENT_TYPE, responseEntity.getHeaders().getContentType().toString());
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+
+        assertModelAndResponse(testViewController.yaml(COMPANY_NUMBER, request, response), 
+                ViewController.APPLICATION_YAML);
     }
     
     private void mockTemplateProcess(String viewName) {
         when(templateEngine.process(eq(viewName), contextCaptor.capture()))
                 .thenReturn(viewName);
+    }
+    
+    private void assertModelAndResponse(ResponseEntity<String> responseEntity, String contentType) {
+        CompanyDetails companyDetails = (CompanyDetails) contextCaptor.getValue()
+                .getVariable(ViewController.CONTEXT_VAR_NAME);
+        assertEquals(COMPANY_NUMBER, companyDetails.getCompanyNumber());
+        String responseContentType = responseEntity.getHeaders().getContentType().toString();
+        assertEquals(contentType, responseContentType.split(";")[0]);
+        assertEquals("charset=UTF-8", responseContentType.split(";")[1]);
+        assertEquals("*",responseEntity.getHeaders().getAccessControlAllowOrigin());
+        assertEquals("no-store, must-revalidate",responseEntity.getHeaders().getCacheControl());
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
     }
 }


### PR DESCRIPTION
:- Extends the list of Accept headers that can be used to request different content types, as follows:
xml: application/xml, application/x-xml
csv: text/csv, text/comma-separated-values, application/csv, application/excel
yaml: application/yaml, application/x-yaml, text/yaml, text/x-yaml

:- Add a CORS http header
Access-Control-Allow-Origin:*

:- Prevents the JSESSIONID cookie from being written out

:- Sets Cache-Control and Pragma response headers to prevent caching of data.

Resolves
CM-56 - Check headers
CM-92 - Add CORS header
CM-94 - Suppress session cookie