### PR TITLE
Guard for null lastAccounts from api

### DIFF
--- a/src/main/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImpl.java
@@ -89,8 +89,10 @@ public class CompanyDetailsTransformerImpl implements CompanyDetailsTransformer 
             }
             accounts.setNextDueDate(transformDate(apiAccounts.getNextDue()));
             LastAccountsApi apiLastAccounts = apiAccounts.getLastAccounts();
-            accounts.setLastMadeUpDate(transformDate(apiLastAccounts.getMadeUpTo()));
-            accounts.setAccountCategory(transformAccountsType(apiLastAccounts.getType()));
+            if (apiLastAccounts != null) {
+                accounts.setLastMadeUpDate(transformDate(apiLastAccounts.getMadeUpTo()));
+                accounts.setAccountCategory(transformAccountsType(apiLastAccounts.getType()));
+            }
         }
         companyDetails.setAccounts(accounts);
         

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -33,15 +33,23 @@ transform.type.investment-company-with-variable-capital=
 transform.type.oversea-company=Other company type
 transform.type.eeig=Other company type
 transform.type.private-limited-shares-section-30-exemption=PRIV LTD SECT. 30 (Private limited company, section 30 of the Companies Act)
+transform.type.converted-or-closed=Converted / Closed
+transform.type.icvc-securities=
+transform.type.icvc-umbrella=
+transform.type.old-public-company=Old Public Company
+transform.type.other=Other company type
+transform.type.private-unlimited-nsc=Private Unlimited
+transform.type.unregistered-company=Other company type
 
 transform.status.active=Active
 transform.status.active-proposal-to-strike-off=Active - Proposal to Strike off
 transform.status.dissolved=Dissolved
-transform.status.administration=ADMINISTRATION ORDER
+transform.status.administration=In Administration
 transform.status.liquidation=Liquidation
 transform.status.voluntary-arrangement=Voluntary Arrangement
 transform.status.receivership=Live but Receiver Manager on at least one charge
 transform.status.insolvency-proceedings=In Administration/Administrative Receiver
+transform.status.converted-closed=Converted / Closed
 
 transform.jurisdiction.england-wales=United Kingdom
 transform.jurisdiction.scotland=United Kingdom
@@ -62,6 +70,9 @@ transform.accounts.unaudited-abridged=UNAUDITED ABRIDGED
 transform.accounts.no-accounts-type-available=ACCOUNTS TYPE NOT AVAILABLE
 transform.accounts.medium=MEDIUM
 transform.accounts.audited-abridged=AUDITED ABRIDGED
+transform.accounts.filing-exemption-subsidiary=FILING EXEMPTION SUBSIDIARY
+transform.accounts.interim=INTERIM
+transform.accounts.partial-exemption=PARTIAL EXEMPTION
 
 transform.sic.0111=0111 - Grow cereals & other crops
 transform.sic.0112=0112 - Grow vegetables & nursery products

--- a/src/test/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImplTest.java
@@ -166,6 +166,17 @@ class CompanyDetailsTransformerImplTest {
         assertEquals(null, companyDetails.getAccounts().getAccountRefMonth());
     }
     
+    @Test
+    void profileApiToDetailsMissingLastAccounts() {
+        CompanyProfileApi companyProfileApi = populatedCompanyProfileApi();
+        companyProfileApi.getAccounts().setLastAccounts(null);;
+
+        CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
+        
+        assertEquals(null, companyDetails.getAccounts().getLastMadeUpDate());
+        assertEquals(null, companyDetails.getAccounts().getAccountCategory());
+    }
+    
     private CompanyProfileApi populatedCompanyProfileApi() {
         CompanyProfileApi companyProfileApi = new CompanyProfileApi();
         

--- a/src/test/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImplTest.java
@@ -41,30 +41,30 @@ class CompanyDetailsTransformerImplTest {
     void profileApiToDetailsEmptyCompanyProfileApi() {
         CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(new CompanyProfileApi());
         
-        assertEquals(null, companyDetails.getCompanyNumber());
-        assertEquals(null, companyDetails.getCompanyName());
-        assertEquals(null, companyDetails.getIncorporationDate());
-        assertEquals(null, companyDetails.getDissolutionDate());
+        assertNull(companyDetails.getCompanyNumber());
+        assertNull(companyDetails.getCompanyName());
+        assertNull(companyDetails.getIncorporationDate());
+        assertNull(companyDetails.getDissolutionDate());
         assertEquals("transform.status.null", companyDetails.getCompanyStatus());
         assertEquals("transform.type.null", companyDetails.getCompanyType());
         assertEquals("transform.jurisdiction.null", companyDetails.getCountryOfOrigin());
-        assertEquals(null, companyDetails.getAccounts().getAccountCategory());
-        assertEquals(null, companyDetails.getAccounts().getAccountRefDay());
-        assertEquals(null, companyDetails.getAccounts().getAccountRefMonth());
-        assertEquals(null, companyDetails.getAccounts().getLastMadeUpDate());
-        assertEquals(null, companyDetails.getAccounts().getNextDueDate());
-        assertEquals(null, companyDetails.getReturns().getLastMadeUpDate());
-        assertEquals(null, companyDetails.getReturns().getNextDueDate());
+        assertNull(companyDetails.getAccounts().getAccountCategory());
+        assertNull(companyDetails.getAccounts().getAccountRefDay());
+        assertNull(companyDetails.getAccounts().getAccountRefMonth());
+        assertNull(companyDetails.getAccounts().getLastMadeUpDate());
+        assertNull(companyDetails.getAccounts().getNextDueDate());
+        assertNull(companyDetails.getReturns().getLastMadeUpDate());
+        assertNull(companyDetails.getReturns().getNextDueDate());
         assertEquals(0, companyDetails.getPreviousNames().length);
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getCareOf());
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getPoBox());
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getPremises());
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getAddressLine1());
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getAddressLine2());
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getPostTown());
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getRegion());
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getCountry());
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getPostCode());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getCareOf());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getPoBox());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getPremises());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getAddressLine1());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getAddressLine2());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getPostTown());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getRegion());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getCountry());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getPostCode());
         assertEquals(1, companyDetails.getSicCodes().getSicText().length);
         assertEquals("None Supplied", companyDetails.getSicCodes().getSicText()[0]);
     }
@@ -142,7 +142,7 @@ class CompanyDetailsTransformerImplTest {
 
         CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
         
-        assertEquals(null, companyDetails.getRegisteredOfficeAddress().getCountry());
+        assertNull(companyDetails.getRegisteredOfficeAddress().getCountry());
     }
     
     @Test
@@ -162,8 +162,8 @@ class CompanyDetailsTransformerImplTest {
 
         CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
         
-        assertEquals(null, companyDetails.getAccounts().getAccountRefDay());
-        assertEquals(null, companyDetails.getAccounts().getAccountRefMonth());
+        assertNull(companyDetails.getAccounts().getAccountRefDay());
+        assertNull(companyDetails.getAccounts().getAccountRefMonth());
     }
     
     @Test
@@ -173,8 +173,8 @@ class CompanyDetailsTransformerImplTest {
 
         CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
         
-        assertEquals(null, companyDetails.getAccounts().getLastMadeUpDate());
-        assertEquals(null, companyDetails.getAccounts().getAccountCategory());
+        assertNull(companyDetails.getAccounts().getLastMadeUpDate());
+        assertNull(companyDetails.getAccounts().getAccountCategory());
     }
     
     private CompanyProfileApi populatedCompanyProfileApi() {


### PR DESCRIPTION
Adds a guard for the case where LastAccounts are mssing from the CHS Company Profile API response.
Also adds some more message keys.

Resolves:
CM-164 - Null Pointer when LastAccounts missing