### PR TITLE
Use links.charges instead of has_charges flag

### DIFF
--- a/src/main/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImpl.java
@@ -35,6 +35,7 @@ public class CompanyDetailsTransformerImpl implements CompanyDetailsTransformer 
     private static final String ACCOUNTS_TYPE_BUNDLE_PREFIX = "transform.accounts.";
     private static final String SIC_BUNDLE_PREFIX = "transform.sic.";
     private static final String NO_SIC_AVAILABLE = "None Supplied";
+    private static final String PROFILE_LINKS_CHARGES = "charges";
     
     private ResourceBundle bundle;
     
@@ -113,7 +114,10 @@ public class CompanyDetailsTransformerImpl implements CompanyDetailsTransformer 
         
         companyDetails.setSicCodes(transformSIC(companyProfileApi.getSicCodes()));
         
-        companyDetails.setHasCharges(companyProfileApi.isHasCharges());
+        if (companyProfileApi.getLinks() != null && 
+                companyProfileApi.getLinks().containsKey(PROFILE_LINKS_CHARGES)) {
+            companyDetails.setHasCharges(true);
+        }
         
         return companyDetails;
     }

--- a/src/test/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImplTest.java
@@ -4,9 +4,13 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListResourceBundle;
+import java.util.Map;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,6 +71,7 @@ class CompanyDetailsTransformerImplTest {
         assertNull(companyDetails.getRegisteredOfficeAddress().getPostCode());
         assertEquals(1, companyDetails.getSicCodes().getSicText().length);
         assertEquals("None Supplied", companyDetails.getSicCodes().getSicText()[0]);
+        assertFalse(companyDetails.hasCharges());
     }
     
     @Test
@@ -105,6 +110,7 @@ class CompanyDetailsTransformerImplTest {
         assertEquals(2, sicCodes.getSicText().length);
         assertEquals("transform.sic.51110", sicCodes.getSicText()[0]);
         assertEquals("transform.sic.23423", sicCodes.getSicText()[1]);
+        assertTrue(companyDetails.hasCharges());
     }
     
     @Test
@@ -177,6 +183,16 @@ class CompanyDetailsTransformerImplTest {
         assertNull(companyDetails.getAccounts().getAccountCategory());
     }
     
+    @Test
+    void profileApiToDetailsMissingChargesLink() {
+        CompanyProfileApi companyProfileApi = populatedCompanyProfileApi();
+        companyProfileApi.getLinks().clear();
+
+        CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
+        
+        assertFalse(companyDetails.hasCharges());
+    }
+    
     private CompanyProfileApi populatedCompanyProfileApi() {
         CompanyProfileApi companyProfileApi = new CompanyProfileApi();
         
@@ -231,6 +247,10 @@ class CompanyDetailsTransformerImplTest {
         
         String[] sicCodes = {"51110", "23423"};
         companyProfileApi.setSicCodes(sicCodes);
+        
+        Map<String,String> links = new TreeMap<>();
+        links.put("charges", "/company/05448736/charges");
+        companyProfileApi.setLinks(links);
         
         return companyProfileApi;
     }


### PR DESCRIPTION
This service is currently determining whether to make an API request for mortage charges based on the company profile API has_charges flag.  This is incorrect as that flag has been deprecated and it should be using links.charges instead.

Resolves:
CM-165