### PR TITLE
Suppress dissolution date if not converted/closed or dissolved status

### DIFF
--- a/src/main/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImpl.java
@@ -40,6 +40,8 @@ public class CompanyDetailsTransformerImpl implements CompanyDetailsTransformer 
     private static final String NO_SIC_AVAILABLE = "None Supplied";
     private static final String PROFILE_LINKS_CHARGES = "charges";
     private static final String OVERSEA_COMPANY = "oversea-company";
+    private static final String COMPANY_STATUS_DISSOLVED = "dissolved";
+    private static final String COMPANY_STATUS_CLOSED = "converted-closed";
     
     private ResourceBundle bundle;
     
@@ -73,7 +75,10 @@ public class CompanyDetailsTransformerImpl implements CompanyDetailsTransformer 
             companyDetails.setCountryOfOrigin(transformCompanyJurisdiction(companyProfileApi.getJurisdiction()));
         }
         
-        companyDetails.setDissolutionDate(transformDate(companyProfileApi.getDateOfCessation()));
+        if (isCompanyDissolved(companyProfileApi)) {
+            companyDetails.setDissolutionDate(transformDate(companyProfileApi.getDateOfCessation()));
+        }
+
         companyDetails.setIncorporationDate(transformDate(companyProfileApi.getDateOfCreation()));
         companyDetails.setPreviousNames(transformPreviousNames(companyProfileApi.getPreviousCompanyNames()));
         
@@ -226,6 +231,14 @@ public class CompanyDetailsTransformerImpl implements CompanyDetailsTransformer 
     
     private int transformChargeCount(Long count) {      
         return count == null ? 0 : count.intValue();   
+    }
+    
+    private boolean isCompanyDissolved(CompanyProfileApi companyProfileApi) {
+        if (COMPANY_STATUS_DISSOLVED.equals(companyProfileApi.getCompanyStatus()) || 
+                COMPANY_STATUS_CLOSED.equals(companyProfileApi.getCompanyStatus())) {
+            return true;
+        }
+        return false;
     }
     
     private String getForeignCompanyRegistryCountry(CompanyProfileApi companyProfileApi) {

--- a/src/main/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImpl.java
@@ -234,11 +234,8 @@ public class CompanyDetailsTransformerImpl implements CompanyDetailsTransformer 
     }
     
     private boolean isCompanyDissolved(CompanyProfileApi companyProfileApi) {
-        if (COMPANY_STATUS_DISSOLVED.equals(companyProfileApi.getCompanyStatus()) || 
-                COMPANY_STATUS_CLOSED.equals(companyProfileApi.getCompanyStatus())) {
-            return true;
-        }
-        return false;
+        return COMPANY_STATUS_DISSOLVED.equals(companyProfileApi.getCompanyStatus()) || 
+                COMPANY_STATUS_CLOSED.equals(companyProfileApi.getCompanyStatus());
     }
     
     private String getForeignCompanyRegistryCountry(CompanyProfileApi companyProfileApi) {

--- a/src/test/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/transformer/CompanyDetailsTransformerImplTest.java
@@ -38,6 +38,8 @@ class CompanyDetailsTransformerImplTest {
 
     private static final String OVERSEA_COMPANY = "oversea-company";
     private static final String ENGLAND_WALES_MESSAGE_KEY = "transform.jurisdiction.england-wales";
+    private static final String COMPANY_STATUS_DISSOLVED = "dissolved";
+    private static final String COMPANY_STATUS_CLOSED = "converted-closed";
     
     private CompanyDetailsTransformer testCompanyDetailsTransformer;
 
@@ -86,7 +88,7 @@ class CompanyDetailsTransformerImplTest {
         assertEquals("05448736", companyDetails.getCompanyNumber());
         assertEquals("Test Company Name Limited", companyDetails.getCompanyName());
         assertEquals("01/01/2017", companyDetails.getIncorporationDate());
-        assertEquals("03/02/2020", companyDetails.getDissolutionDate());
+        assertNull(companyDetails.getDissolutionDate());
         assertEquals("transform.status.status-detail", companyDetails.getCompanyStatus());
         assertEquals("transform.type.ltd", companyDetails.getCompanyType());
         assertEquals(ENGLAND_WALES_MESSAGE_KEY, companyDetails.getCountryOfOrigin());
@@ -229,6 +231,36 @@ class CompanyDetailsTransformerImplTest {
         CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
         
         assertEquals(ENGLAND_WALES_MESSAGE_KEY, companyDetails.getCountryOfOrigin());
+    }
+    
+    @Test
+    void profileApiToDetailsDissolvedCompany() {
+        CompanyProfileApi companyProfileApi = populatedCompanyProfileApi();
+        companyProfileApi.setCompanyStatus(COMPANY_STATUS_DISSOLVED);
+
+        CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
+        
+        assertEquals("03/02/2020", companyDetails.getDissolutionDate());
+    }
+    
+    @Test
+    void profileApiToDetailsConvertedClosedCompany() {
+        CompanyProfileApi companyProfileApi = populatedCompanyProfileApi();
+        companyProfileApi.setCompanyStatus(COMPANY_STATUS_CLOSED);
+
+        CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
+        
+        assertEquals("03/02/2020", companyDetails.getDissolutionDate());
+    }
+    
+    @Test
+    void profileApiToDetailsActiveCompany() {
+        CompanyProfileApi companyProfileApi = populatedCompanyProfileApi();
+        companyProfileApi.setCompanyStatus("anything else");
+
+        CompanyDetails companyDetails = testCompanyDetailsTransformer.profileApiToDetails(companyProfileApi);
+        
+        assertNull(companyDetails.getDissolutionDate());
     }
     
     private CompanyProfileApi populatedCompanyProfileApi() {


### PR DESCRIPTION
For some active companies, typically those that have been restored, the date_of_cessation is being returned from the CHS Company Profile API. This is currently being displayed as DissolutionDate, but this should only be shown if the company has a status of Dissolved or Closed/Converted.

Resolves:
CM-167