### PR TITLE
Add missing message keys

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -42,6 +42,11 @@ transform.type.other=Other company type
 transform.type.private-unlimited-nsc=Private Unlimited
 transform.type.unregistered-company=Other company type
 transform.type.european-public-limited-liability-company-se=European Public Limited-Liability Company (SE)
+transform.type.protected-cell-company=Protected Cell Company
+transform.type.charitable-incorporated-organisation=Charitable incorporated organisation
+transform.type.further-education-or-sixth-form-college-corporation=Further education or sixth form college corporation
+transform.type.scottish-charitable-incorporated-organisation=Scottish charitable incorporated organisation
+transform.type.ukeig=United Kingdom Economic Interest Grouping
 
 transform.status.active=Active
 transform.status.active-proposal-to-strike-off=Active - Proposal to Strike off
@@ -55,12 +60,17 @@ transform.status.converted-closed=Converted / Closed
 transform.status.transferred-from-uk=Transferred from UK
 transform.status.closed=Transformed to SE
 transform.status.transformed-to-se=Transformed to SE
+transform.status.null=
+transform.status.converted-to-ukeig=Converted to UKEIG
+transform.status.converted-to-plc=Converted to PLC
+transform.status.converted-to-uk-societas=Converted to UK Societas
 
 transform.jurisdiction.england-wales=United Kingdom
 transform.jurisdiction.scotland=United Kingdom
 transform.jurisdiction.northern-ireland=United Kingdom
 transform.jurisdiction.united-kingdom=United Kingdom
 transform.jurisdiction.wales=United Kingdom
+transform.jurisdiction.null=
 
 transform.accounts.null=NO ACCOUNTS FILED
 transform.accounts.group=GROUP


### PR DESCRIPTION
Adds the following entries, that were noticed to be missing during testing:

transform.type.protected-cell-company=Protected Cell Company
transform.type.charitable-incorporated-organisation=Charitable incorporated organisation
transform.type.further-education-or-sixth-form-college-corporation=Further education or sixth form college corporation
transform.type.scottish-charitable-incorporated-organisation=Scottish charitable incorporated organisation
transform.type.ukeig=United Kingdom Economic Interest Grouping
transform.jurisdiction.null=
transform.status.null=
transform.status.converted-to-ukeig=Converted to UKEIG
transform.status.converted-to-plc=Converted to PLC
transform.status.converted-to-uk-societas=Converted to UK Societas
