### PR TITLE
Update structured logging version to 1.9.10 for log4j update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,23 @@
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
         </dependency>
+        
+        <!-- Override log4j versions -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.15.0</version>
+        </dependency>
 
         <!-- test -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <java.version>1.8</java.version>
         <api-sdk-java.version>4.2.40</api-sdk-java.version>
-        <structured-logging.version>1.9.0</structured-logging.version>
+        <structured-logging.version>1.9.10</structured-logging.version>
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>        
         <mock-server.version>5.5.4</mock-server.version>
         <commons-validator.version>1.7</commons-validator.version>


### PR DESCRIPTION
Update the structured logging library and also explicitly override the log4j versions, to prevent the older version of spring boot referencing older versions.

Resolves: https://companieshouse.atlassian.net/browse/DEBT-1483