### PR TITLE
DEBT-1533 Upgrade Log4J version to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,18 @@
             ${project.basedir}/target/site/jacoco/jacoco.xml,
             ${project.basedir}/target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
+        <log4j.version>2.17.0</log4j.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -116,23 +124,6 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>structured-logging</artifactId>
             <version>${structured-logging.version}</version>
-        </dependency>
-        
-        <!-- Override log4j versions -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.15.0</version>
         </dependency>
 
         <!-- test -->


### PR DESCRIPTION
- Upgrade Log4J version to **2.17.0**


[dependency-tree.txt](https://github.com/companieshouse/uri-web/files/7744859/dependency-tree.txt)

Related to: [rebuild app with 2.16.0 - uri-web](https://companieshouse.atlassian.net/browse/DEBT-1533)
