### PR TITLE
Update structured logging to 1.9.12 and remove pinned log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <java.version>1.8</java.version>
         <api-sdk-java.version>4.2.40</api-sdk-java.version>
-        <structured-logging.version>1.9.10</structured-logging.version>
+        <structured-logging.version>1.9.12</structured-logging.version>
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>        
         <mock-server.version>5.5.4</mock-server.version>
         <commons-validator.version>1.7</commons-validator.version>
@@ -50,13 +50,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>${log4j.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Relates to https://companieshouse.atlassian.net/browse/DEBT-1575?src=confmacro

Debt-1575: Upgrade uri-web to 2.17.0 and 1.9.12

Note: I have removed the pinned log4j dependency as this was not required for log4j-core, per guidance here: https://companieshouse.atlassian.net/wiki/spaces/Arch/pages/3587637603/Log4J+2+Vulnerability+-+Developer+advice

For reassurance, I ran `mvn dependency:tree | grep log4j` and got:

```                                                      
[INFO] |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.12.1:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-api:jar:2.12.1:compile
```

i.e. log4j-to-slf4j and log4j-api (which cannot be exploited in isolation) and _not_ log4j-core
