### PR TITLE
Add redirect for business.data.gov.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Variable | Description|Example| Default
 -|-|-|-
 `CHS_API_KEY` |The API key to use to authenticate with the CHS APIs (see https://developer.companieshouse.gov.uk). Provided by global env on CHS environment.|`7aPeBkeorUFphM_6PKrMuI-uB9r-3Z92bBe1iTT0`|N/A
 `API_URL`|The URL of the CHS API to use. Provided by global env on CHS environment.|https://api.companieshouse.gov.uk|N/A
+`REDIRECT_URI_PREFIX`|The URL to redirect requests received for /id/company/*. These requests are normally when the business.data.gov.uk address has been used and need to be redirected to the CH version of the address|http://data-staging.companieshouse.gov.uk/doc/company|N/A
 
 Optional environment variables, mainly for links and common Javascript/CSS on error pages:
 

--- a/src/main/java/uk/gov/companieshouse/uri/web/controller/RedirectController.java
+++ b/src/main/java/uk/gov/companieshouse/uri/web/controller/RedirectController.java
@@ -1,0 +1,36 @@
+package uk.gov.companieshouse.uri.web.controller;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/id/company/*")
+public class RedirectController {
+    
+    @Value("${redirect.uri.prefix}")
+    private String redirectURIPrefix;
+
+    @GetMapping
+    public ResponseEntity<String> redirect(HttpServletRequest request,
+            HttpServletResponse response) throws URISyntaxException {
+        
+        return ResponseEntity.status(HttpStatus.SEE_OTHER)
+                .location(getRedirectURI(request)).build();
+    }
+    
+    private URI getRedirectURI(HttpServletRequest request) throws URISyntaxException {
+        String originalURIPath = request.getRequestURI();
+        String lastPathElement = originalURIPath.substring(originalURIPath.lastIndexOf('/'));
+        return new URI(redirectURIPrefix + lastPathElement);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,5 +5,6 @@ chs.url=${CHS_URL}
 govuk.ch.url=${GOVUK_CH_URL}
 api.url=${API_URL}
 cdn.url=//${CDN_HOST}
+redirect.uri.prefix=${REDIRECT_URI_PREFIX}
 #Turn off JSESSIONID cookie
 server.servlet.session.tracking-modes=

--- a/src/test/java/uk/gov/companieshouse/uri/web/controller/RedirectControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/uri/web/controller/RedirectControllerTest.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.uri.web.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.net.URISyntaxException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RedirectControllerTest {
+
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String INVALID_REDIRECT_URI_PREFIX = "xttp://test-server/doc/company";
+    private static final String VALID_REDIRECT_URI_PREFIX = "http://test-server/doc/company";
+    
+    private RedirectController testRedirectController;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+    
+    @Mock
+    private HttpServletRequest request;
+    
+    @Mock
+    private HttpServletResponse response;
+
+    @BeforeEach
+    protected void setUp() {
+        testRedirectController = new RedirectController();
+    }
+
+    @Test
+    void redirectWithValidRedirectPrefix() throws URISyntaxException {     
+        ReflectionTestUtils.setField(testRedirectController, "redirectURIPrefix", VALID_REDIRECT_URI_PREFIX);
+        when(request.getRequestURI()).thenReturn("/id/company/" + COMPANY_NUMBER);
+        
+        ResponseEntity<String> responseEntity = testRedirectController.redirect(request, response);
+        
+        assertEquals(HttpStatus.SEE_OTHER, responseEntity.getStatusCode());
+        
+        HttpHeaders headers = responseEntity.getHeaders();
+        String locationHeader = headers.get("location").get(0);
+        assertEquals(VALID_REDIRECT_URI_PREFIX + "/" + COMPANY_NUMBER, locationHeader);
+    }
+    
+    @Test
+    void redirectWithInValidRedirectPrefix() throws URISyntaxException {     
+        ReflectionTestUtils.setField(testRedirectController, "redirectURIPrefix", INVALID_REDIRECT_URI_PREFIX);
+        when(request.getRequestURI()).thenReturn("/id/company/" + COMPANY_NUMBER);
+        
+        exception.expect(URISyntaxException.class);
+        testRedirectController.redirect(request, response);
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,2 +1,3 @@
 chs.api.key=
 api.url=
+redirect.uri.prefix=


### PR DESCRIPTION
Re-implement the redirect for business.data.gov.uk/id/company/* to data.companieshouse.gov.uk/doc/company/* on the uri-web microservice.  This allows us to decommission the remaining on-prem WebCheck infrastructure where the redirect is currently implemented.

A new env var `REDIRECT_URI_PREFIX` is introduced, that allows us to set the URL prefix for the redirect.  This is required and will normally be set as follows:
STAGING: "//data-staging.companieshouse.gov.uk/doc/company" 
LIVE: "//data.companieshouse.gov.uk/doc/company" 

Resolves: https://companieshouse.atlassian.net/browse/CM-1440