### PR TITLE
Add new message keys for overseas entities

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -50,6 +50,7 @@ transform.type.ukeig=United Kingdom Economic Interest Grouping
 transform.type.northern-ireland=Northern Ireland company
 transform.type.united-kingdom-societas=United Kingdom Societas
 transform.type.scottish-partnership=Scottish qualifying partnership
+transform.type.registered-overseas-entity=Overseas entity
 
 transform.status.active=Active
 transform.status.active-proposal-to-strike-off=Active - Proposal to Strike off
@@ -67,6 +68,7 @@ transform.status.null=
 transform.status.converted-to-ukeig=Converted to UKEIG
 transform.status.converted-to-plc=Converted to PLC
 transform.status.converted-to-uk-societas=Converted to UK Societas
+transform.status.registered=Registered
 
 transform.jurisdiction.england-wales=United Kingdom
 transform.jurisdiction.scotland=United Kingdom


### PR DESCRIPTION
Add the following message keys, as they are missing when displaying Overseas Entities:

```
transform.type.registered-overseas-entity=Overseas entity
transform.status.registered=Registered
```

Resolves: https://companieshouse.atlassian.net/browse/ROE-1118