### PR TITLE
fix: update lb name

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -34,7 +34,7 @@ data "aws_iam_role" "ecs_cluster_iam_role" {
 }
 
 data "aws_lb" "service_lb" {
-  name = "${var.environment}-uri-web"
+  name = "${var.environment}-chs-uri-web"
 }
 
 data "aws_lb_listener" "service_lb_listener" {


### PR DESCRIPTION
to fix

```
│ Error: reading ELBv2 Load Balancers: couldn't find resource
│ 
│   with data.aws_lb.service_lb,
│   on data.tf line 36, in data "aws_lb" "service_lb":
│   36: data "aws_lb" "service_lb" {
│ 
╵
Error: Terraform command exited with exit code: 1
```