### PR TITLE
Update listener path to "/*' to forward all requests to service

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -8,7 +8,7 @@ locals {
   docker_repo                 = "uri-web"
   kms_alias                   = "alias/${var.aws_profile}/environment-services-kms"
   lb_listener_rule_priority   = 93
-  lb_listener_paths           = ["/doc/company/*"]
+  lb_listener_paths           = ["/*"]
   healthcheck_path            = "/uri-web/healthcheck" #replace with Healthcheck supplied by scrum team
   healthcheck_matcher         = "200"
   vpc_name                    = local.stack_secrets["vpc_name"]


### PR DESCRIPTION
The uri-web service runs behind a standalone ALB and there are static resources that need to be loaded from paths other than /doc/company, such as /images & /css.

This updates the listener path to be "/*" so that all requests received by the ALB are forwarded to the service.