### PR TITLE
Add additional http listener rule

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -37,9 +37,22 @@ data "aws_lb" "service_lb" {
   name = "${var.environment}-chs-uri-web"
 }
 
-data "aws_lb_listener" "service_lb_listener" {
+data "aws_lb_listener" "service_lb_443_listener" {
   load_balancer_arn = data.aws_lb.service_lb.arn
   port = 443
+}
+
+data "aws_lb_listener" "service_lb_80_listener" {
+  load_balancer_arn = data.aws_lb.service_lb.arn
+  port = 80
+}
+
+data "aws_lb_target_group" "target_group" {
+  name = var.use_fargate ? "${var.environment}-${local.service_name}-far" : "${var.environment}-${local.service_name}"
+
+  depends_on = [
+    module.ecs-service
+  ]
 }
 
 # retrieve all secrets for this stack using the stack path

--- a/terraform/groups/ecs-service/http-listener.tf
+++ b/terraform/groups/ecs-service/http-listener.tf
@@ -1,0 +1,26 @@
+resource "aws_lb_listener_rule" "http_listener_rule" {
+  listener_arn = data.aws_lb_listener.service_lb_80_listener.arn
+  priority     = local.lb_listener_rule_priority * 10
+
+  action {
+    type             = "forward"
+    target_group_arn = data.aws_lb_target_group.target_group.arn
+  }
+  condition {
+    path_pattern {
+      values = local.lb_listener_paths
+    }
+  }
+
+  tags = {
+      ServiceName        = local.service_name
+      ECSClusterName     = "${local.name_prefix}-cluster"
+      Environment        = var.environment
+      UseFargate         = var.use_fargate
+      ManagedByTerraform = "true"
+  }
+
+  depends_on = [
+    module.ecs-service
+  ]
+}

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -31,7 +31,7 @@ module "ecs-service" {
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
 
   # Load balancer configuration
-  lb_listener_arn                 = data.aws_lb_listener.service_lb_listener.arn
+  lb_listener_arn                 = data.aws_lb_listener.service_lb_443_listener.arn
   lb_listener_rule_priority       = local.lb_listener_rule_priority
   lb_listener_paths               = local.lb_listener_paths
 


### PR DESCRIPTION
Traffic needs to be directed to this service from the standalone ALB when using http as well as https.  Therefore, we need a listener rule added to both http & https listeners on the ALB.

Currently, the ecs-service module only supports adding listener rules to one listener, unless the multi-lb configuration is used.  Unfortunately, there is an issue with duplicate security groups when using the multi-lb configuration with the same ALB, so this adds the additional listener rule outside the ecs-service module.