### PR TITLE
use latest dependency-check setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,7 @@ artifact_name       := uri-web
 version             := unversioned
 
 dependency_check_base_suppressions:=common_suppressions_spring_6.xml
-
-# dependency_check_suppressions_repo_branch
-# The branch of the dependency-check-suppressions repository to use
-# as the source of the suppressions file.
-# This should point to "main" branch when being used for release,
-# but can point to a different branch for experimentation/development.
-dependency_check_suppressions_repo_branch:=feature/suppressions-for-company-accounts-api
-
+dependency_check_suppressions_repo_branch:=main
 dependency_check_minimum_cvss := 4
 dependency_check_assembly_analyzer_enabled := false
 dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
@@ -71,32 +64,31 @@ sonar:
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
 
-##### Start of dependency-check block to be put at bottom of Makefile
 .PHONY: dependency-check
 dependency-check:
-	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then   \
+	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
 		suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
 	fi; \
-	if [ ! -d "$${suppressions_home}" ]; then   \
-		suppressions_home_target_dir="./target/dependency-check-suppressions";  \
-		if [ -d "$${suppressions_home_target_dir}" ]; then  \
-			suppressions_home="$${suppressions_home_target_dir}";   \
-			else    \
-		mkdir -p "./target";    \
-			git clone $(dependency_check_suppressions_repo_url) "$${suppressions_home_target_dir}" && \
+	if [ ! -d "$${suppressions_home}" ]; then \
+	    suppressions_home_target_dir="./target/dependency-check-suppressions"; \
+		if [ -d "$${suppressions_home_target_dir}" ]; then \
 			suppressions_home="$${suppressions_home_target_dir}"; \
+		else \
+			mkdir -p "./target"; \
+			git clone $(dependency_check_suppressions_repo_url) "$${suppressions_home_target_dir}" && \
+				suppressions_home="$${suppressions_home_target_dir}"; \
 			if [ -d "$${suppressions_home_target_dir}" ] && [ -n "$(dependency_check_suppressions_repo_branch)" ]; then \
-			cd "$${suppressions_home}"; \
-			git checkout $(dependency_check_suppressions_repo_branch); \
-			cd -; \
+				cd "$${suppressions_home}"; \
+				git checkout $(dependency_check_suppressions_repo_branch); \
+				cd -; \
 			fi; \
 		fi; \
 	fi; \
 	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
 	if [  -f "$${suppressions_path}" ]; then \
 		cp -av "$${suppressions_path}" $(suppressions_file); \
-		mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
-		else \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+	else \
 		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
 		exit 1; \
 	fi
@@ -104,4 +96,3 @@ dependency-check:
 .PHONY: security-check
 security-check: dependency-check
 
-##### End of dependency-check block

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.11</version>
         <relativePath/>
     </parent>
     <artifactId>uri-web</artifactId>


### PR DESCRIPTION
c867114 Update parent pom to 2.1.11
2.1.11 brings in latest correct dependency-check settings.

1083915 Repoint Makefile at dep-check-suppressions/main
The 'dependency-check' target uses a variable
dependency_check_suppressions_repo_branch
which previously pointed to a different branch:
feature/suppressions-for-company-accounts-api
... but that branch has been merged into main and so this variable
should now point to main.
Tidy Makefile for dependency-check consistency
Remove extraneous comments.
Make line spacing, ordering, format for dependency-check sections
identical across Makefiles.
Add json to dependency check report formats

Fixes [CC-1760](https://companieshouse.atlassian.net/browse/CC-1760)

[CC-1760]: https://companieshouse.atlassian.net/browse/CC-1760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ