### PR TITLE
Add healthcheck parameters for task container startup delay

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -40,6 +40,12 @@ module "ecs-service" {
   healthcheck_path                  = local.healthcheck_path
   healthcheck_matcher               = local.healthcheck_matcher
 
+  # Pass health check configuration, including optional start period
+  task_healthcheck_interval     = var.task_healthcheck_interval
+  task_healthcheck_timeout      = var.task_healthcheck_timeout
+  task_healthcheck_retries      = var.task_healthcheck_retries
+  task_healthcheck_start_period  = var.task_healthcheck_start_period
+
   # Docker container details
   docker_registry   = var.docker_registry
   docker_repo       = local.docker_repo

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -8,3 +8,9 @@ use_set_environment_files = true
 service_autoscale_enabled  = true
 service_scaledown_schedule = "55 19 * * ? *"
 service_scaleup_schedule   = "5 6 * * ? *"
+
+# task container healthcheck parameters
+task_healthcheck_interval = 60
+task_healthcheck_timeout = 10
+task_healthcheck_retries = 3
+task_healthcheck_start_period = 180

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -11,3 +11,9 @@ min_task_count     = 2
 
 required_cpus = 512
 required_memory = 1024
+
+# task container healthcheck parameters
+task_healthcheck_interval = 60
+task_healthcheck_timeout = 10
+task_healthcheck_retries = 3
+task_healthcheck_start_period = 180

--- a/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
+++ b/terraform/groups/ecs-service/profiles/staging-eu-west-2/staging/vars
@@ -8,3 +8,9 @@ use_set_environment_files = true
 service_autoscale_enabled  = true
 service_scaledown_schedule = "55 19 * * ? *"
 service_scaleup_schedule   = "5 6 * * ? *"
+
+# task container healthcheck parameters
+task_healthcheck_interval = 60
+task_healthcheck_timeout = 10
+task_healthcheck_retries = 3
+task_healthcheck_start_period = 180

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -119,3 +119,26 @@ variable "uri_web_version" {
   type        = string
   description = "The version of the uri-web service container to run."
 }
+
+# ------------------------------------------------------------------------------
+# Health check environment variable configs
+# ------------------------------------------------------------------------------
+variable "task_healthcheck_interval" {
+  type        = number
+  description = "Health check interval configuration for ECS task definitions."
+}
+
+variable "task_healthcheck_timeout" {
+  type        = number
+  description = "Health check timeout configuration for ECS task definitions."
+}
+
+variable "task_healthcheck_retries" {
+  type        = number
+  description = "Health check retries configuration for ECS task definitions."
+}
+
+variable "task_healthcheck_start_period" {
+  type        = number
+  description = "Health check start period configuration for ECS task definitions."
+}


### PR DESCRIPTION
This pull request introduces configurable health check parameters for ECS task containers across all environments. It adds new variables for health check interval, timeout, retries, and start period, and ensures these are passed through the Terraform module and set in each environment's configuration.

**Health Check Configuration Enhancements:**

* Added new variables for `task_healthcheck_interval`, `task_healthcheck_timeout`, `task_healthcheck_retries`, and `task_healthcheck_start_period` to `variables.tf` so these parameters can be configured per environment.
* Updated the `ecs-service` module in `main.tf` to pass these new health check variables to the underlying ECS task definition.

**Environment-Specific Configuration:**

* Set default values for the new health check parameters in the `development-eu-west-2/cidev`, `staging-eu-west-2/staging`, and `live-eu-west-2/live` environment variable files to ensure consistent health check behavior across all environments. [[1]](diffhunk://#diff-d5029a552307f152682415f04d29123d2eb46262dc5764773c4a1df02f62fa62R11-R16) [[2]](diffhunk://#diff-86a089873d90ef094bda4fcd897fb6fad57f6e23b6694efcab1fd834176b646eR11-R16) [[3]](diffhunk://#diff-4e21e918e8f7abb3669a6a84858739eaf0d5d82c28c5ac40f4277530fbd63ccbR14-R19)
